### PR TITLE
Fix pipe lighting

### DIFF
--- a/flappy.py
+++ b/flappy.py
@@ -113,8 +113,8 @@ def main():
         # select random pipe sprites
         pipeindex = random.randint(0, len(PIPES_LIST) - 1)
         IMAGES['pipe'] = (
-            pygame.transform.rotate(
-                pygame.image.load(PIPES_LIST[pipeindex]).convert_alpha(), 180),
+            pygame.transform.flip(
+                pygame.image.load(PIPES_LIST[pipeindex]).convert_alpha(), False, True),
             pygame.image.load(PIPES_LIST[pipeindex]).convert_alpha(),
         )
 


### PR DESCRIPTION
Flip the upper pipe instead of rotating it to match the lighting of the lower's.